### PR TITLE
catch async express error

### DIFF
--- a/packages/api/src/controllers/AuthController.ts
+++ b/packages/api/src/controllers/AuthController.ts
@@ -1,26 +1,30 @@
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import { compareSync } from 'bcrypt';
 import jwt from 'jsonwebtoken';
 import { unauthorized } from '@hapi/boom';
 import { SECRET_KEY } from 'src/constants';
 import users from 'src/data/users.json';
 
-const login = async (req: Request, res: Response) => {
+const login = async (req: Request, res: Response, next: NextFunction) => {
   const email = req.body.email;
   const password = req.body.password;
   const INCORRECT_LOGIN = 'Incorrect login or password';
 
   const user = users.find((user) => user.email === email);
 
-  if (!user) {
-    throw unauthorized(INCORRECT_LOGIN);
-  } else if (!compareSync(password, user.password)) {
-    throw unauthorized(INCORRECT_LOGIN);
-  } else {
-    const { password, ...userData } = user;
-    const token = jwt.sign({ userData }, SECRET_KEY, { expiresIn: '1y' });
+  try {
+    if (!user) {
+      throw unauthorized(INCORRECT_LOGIN);
+    } else if (!compareSync(password, user.password)) {
+      throw unauthorized(INCORRECT_LOGIN);
+    } else {
+      const { password, ...userData } = user;
+      const token = jwt.sign({ userData }, SECRET_KEY, { expiresIn: '1y' });
 
-    res.status(200).json({ token });
+      res.status(200).json({ token });
+    }
+  } catch (error) {
+    next(error)
   }
 };
 


### PR DESCRIPTION
Async errors are not caught by express unless it's the version alpha v5 (for how many years now?).
This is annoying in the login call as wrong pw/email will simply crash the app without nodemon restarting it.
After the fix error middleware is triggered and returns error message without crashing the api.